### PR TITLE
refactor: add reusable http client

### DIFF
--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1,85 +1,40 @@
-import { API_CONFIG, type ApiResponse, type LoginResponse, type EventoBackend, type DashboardData } from "./api-config"
+import {
+  API_CONFIG,
+  type ApiResponse,
+  type LoginResponse,
+  type EventoBackend,
+  type DashboardData,
+} from "./api-config"
+import { httpClient } from "./http-client"
 
-class ApiService {
-  private baseUrl: string
-  private token: string | null = null
-
-  constructor() {
-    this.baseUrl = API_CONFIG.BASE_URL
-    // Obtener token del localStorage si existe
-    if (typeof window !== "undefined") {
-      this.token = localStorage.getItem("auth_token")
-    }
-  }
-
-  private async request<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
-    const url = `${this.baseUrl}${endpoint}`
-
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      ...options.headers,
-    }
-
-    // Agregar token de autorización si existe
-    if (this.token) {
-      headers.Authorization = `Bearer ${this.token}`
-    }
-
-    try {
-      const response = await fetch(url, {
-        ...options,
-        headers,
-      })
-
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.message || "Error en la petición")
-      }
-
-      return data
-    } catch (error) {
-      console.error("API Error:", error)
-      throw error
-    }
-  }
-
-  // Métodos de autenticación
+export const apiService = {
   async login(correo: string, contrasena: string): Promise<LoginResponse> {
-    const response = await this.request<LoginResponse>(API_CONFIG.ENDPOINTS.LOGIN, {
-      method: "POST",
-      body: JSON.stringify({ correo, contrasena }),
+    const response = await httpClient.post<ApiResponse<LoginResponse>>(API_CONFIG.ENDPOINTS.LOGIN, {
+      correo,
+      contrasena,
     })
 
     if (response.token) {
-      this.token = response.token
-      localStorage.setItem("auth_token", response.token)
+      httpClient.setToken(response.token)
     }
 
-    return response.data || (response as LoginResponse)
-  }
+    return response.data || (response as unknown as LoginResponse)
+  },
 
-  async register(userData: {
+  register(userData: {
     nombre: string
     correo: string
     contrasena: string
     rol: "admin" | "docente" | "estudiante"
   }): Promise<ApiResponse> {
-    return this.request(API_CONFIG.ENDPOINTS.REGISTER, {
-      method: "POST",
-      body: JSON.stringify(userData),
-    })
-  }
+    return httpClient.post<ApiResponse>(API_CONFIG.ENDPOINTS.REGISTER, userData)
+  },
 
-  async verifyEmail(correo: string, codigo: string): Promise<ApiResponse> {
-    return this.request(API_CONFIG.ENDPOINTS.VERIFY_EMAIL, {
-      method: "POST",
-      body: JSON.stringify({ correo, codigo }),
-    })
-  }
+  verifyEmail(correo: string, codigo: string): Promise<ApiResponse> {
+    return httpClient.post<ApiResponse>(API_CONFIG.ENDPOINTS.VERIFY_EMAIL, { correo, codigo })
+  },
 
-  // Métodos de eventos
-  async createEvent(eventData: {
+  createEvent(eventData: {
     titulo: string
     ubicacion: {
       latitud: number
@@ -88,59 +43,42 @@ class ApiService {
     fechaInicio: string
     rangoPermitido: number
   }): Promise<ApiResponse<EventoBackend>> {
-    return this.request(API_CONFIG.ENDPOINTS.CREATE_EVENT, {
-      method: "POST",
-      body: JSON.stringify(eventData),
-    })
-  }
+    return httpClient.post<ApiResponse<EventoBackend>>(API_CONFIG.ENDPOINTS.CREATE_EVENT, eventData)
+  },
 
-  async getEvents(): Promise<ApiResponse<EventoBackend[]>> {
-    return this.request(API_CONFIG.ENDPOINTS.LIST_EVENTS)
-  }
+  getEvents(): Promise<ApiResponse<EventoBackend[]>> {
+    return httpClient.get<ApiResponse<EventoBackend[]>>(API_CONFIG.ENDPOINTS.LIST_EVENTS)
+  },
 
-  async finalizeEvent(eventoId: string): Promise<ApiResponse> {
-    return this.request(`${API_CONFIG.ENDPOINTS.FINALIZE_EVENT}/${eventoId}`, {
-      method: "POST",
-    })
-  }
+  finalizeEvent(eventoId: string): Promise<ApiResponse> {
+    return httpClient.post<ApiResponse>(`${API_CONFIG.ENDPOINTS.FINALIZE_EVENT}/${eventoId}`)
+  },
 
-  // Métodos de asistencia
-  async registerAttendance(data: {
+  registerAttendance(data: {
     eventoId: string
     latitud: number
     longitud: number
   }): Promise<ApiResponse> {
-    return this.request(API_CONFIG.ENDPOINTS.REGISTER_ATTENDANCE, {
-      method: "POST",
-      body: JSON.stringify(data),
-    })
-  }
+    return httpClient.post<ApiResponse>(API_CONFIG.ENDPOINTS.REGISTER_ATTENDANCE, data)
+  },
 
-  // Métodos de dashboard
-  async getDashboardData(): Promise<ApiResponse<DashboardData>> {
-    return this.request(API_CONFIG.ENDPOINTS.DASHBOARD_DATA)
-  }
+  getDashboardData(): Promise<ApiResponse<DashboardData>> {
+    return httpClient.get<ApiResponse<DashboardData>>(API_CONFIG.ENDPOINTS.DASHBOARD_DATA)
+  },
 
-  // Métodos de justificaciones
-  async createJustification(data: any): Promise<ApiResponse> {
-    return this.request(API_CONFIG.ENDPOINTS.CREATE_JUSTIFICATION, {
-      method: "POST",
-      body: JSON.stringify(data),
-    })
-  }
+  createJustification(data: any): Promise<ApiResponse> {
+    return httpClient.post<ApiResponse>(API_CONFIG.ENDPOINTS.CREATE_JUSTIFICATION, data)
+  },
 
-  // Método para cerrar sesión
   logout(): void {
-    this.token = null
-    localStorage.removeItem("auth_token")
-    localStorage.removeItem("user")
-  }
+    httpClient.clearToken()
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("user")
+    }
+  },
 
-  // Método para establecer token
   setToken(token: string): void {
-    this.token = token
-    localStorage.setItem("auth_token", token)
-  }
+    httpClient.setToken(token)
+  },
 }
 
-export const apiService = new ApiService()

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -1,0 +1,75 @@
+import { API_CONFIG } from "./api-config"
+
+class HttpClient {
+  private baseUrl: string = API_CONFIG.BASE_URL
+  private token: string | null
+
+  constructor() {
+    this.token = typeof window !== "undefined" ? localStorage.getItem("auth_token") : null
+  }
+
+  setToken(token: string) {
+    this.token = token
+    if (typeof window !== "undefined") {
+      localStorage.setItem("auth_token", token)
+    }
+  }
+
+  clearToken() {
+    this.token = null
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("auth_token")
+    }
+  }
+
+  private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+      ...options.headers,
+    }
+
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`
+    }
+
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...options,
+      headers,
+    })
+
+    const data = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      throw new Error(data.message || response.statusText)
+    }
+
+    return data as T
+  }
+
+  get<T>(endpoint: string, options?: RequestInit) {
+    return this.request<T>(endpoint, { ...options, method: "GET" })
+  }
+
+  post<T>(endpoint: string, body?: any, options?: RequestInit) {
+    return this.request<T>(endpoint, {
+      ...options,
+      method: "POST",
+      body: body ? JSON.stringify(body) : undefined,
+    })
+  }
+
+  put<T>(endpoint: string, body?: any, options?: RequestInit) {
+    return this.request<T>(endpoint, {
+      ...options,
+      method: "PUT",
+      body: body ? JSON.stringify(body) : undefined,
+    })
+  }
+
+  delete<T>(endpoint: string, options?: RequestInit) {
+    return this.request<T>(endpoint, { ...options, method: "DELETE" })
+  }
+}
+
+export const httpClient = new HttpClient()
+


### PR DESCRIPTION
## Summary
- add HTTP client utility to centralize fetch logic and token storage
- refactor API service to use new client for backend requests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68917d0013ec8330b6358331e259ea5a