### PR TITLE
fix: align API endpoints with backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,24 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## API Endpoints
+
+The project consumes a REST API whose endpoints are documented in
+[`docs/postman-collection.json`](docs/postman-collection.json). The table
+below shows how each endpoint is used inside the application:
+
+| Endpoint | Function in `apiService` | Used in |
+| --- | --- | --- |
+| `/api/usuarios/login` | `login` | `contexts/auth-context.tsx` via `<LoginForm />` |
+| `/api/usuarios/registrar` | `register` | _Registration flow (to be implemented)_ |
+| `/api/usuarios/verificar-correo` | `verifyEmail` | _Email verification (to be implemented)_ |
+| `/api/eventos/crear` | `createEvent` | `hooks/use-events.ts` → `<EventsManagement />` |
+| `/api/eventos/listar` | `getEvents` | `hooks/use-events.ts` → `<EventsManagement />` |
+| `/api/eventos/finalizar` | `finalizeEvent` | `hooks/use-events.ts` → `<EventsManagement />` |
+| `/api/asistencia/registrar` | `registerAttendance` | _Attendance registration (future pages)_ |
+| `/api/dashboard/datos` | `getDashboardData` | `hooks/use-websocket.ts` → `<EnhancedDashboard />` |
+| `/api/justificaciones/crear` | `createJustification` | _Justification creation (future pages)_ |
+
+These mappings make it easier to locate where each API call is triggered in
+the user interface.

--- a/docs/postman-collection.json
+++ b/docs/postman-collection.json
@@ -1,0 +1,302 @@
+{
+"info": {
+"_postman_id": "28f082c0-9779-4038-b386-d350d26ede08",
+"name": "Proyecto Movil",
+"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+"_exporter_id": "36929089",
+"_collection_link": "https://bomberos-el-pangui.postman.co/workspace/My-Workspace~8106d375-436c-426d-88e3-c7d7f64f9901/collection/36929089-28f082c0-9779-4038-b386-d350d26ede08?action=share&source=collection_link&creator=36929089"
+},
+"item": [
+{
+"name": "Usuarios",
+"item": [
+{
+"name": "New Request",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "Login",
+"request": {
+"method": "POST",
+"header": [],
+"body": {
+"mode": "raw",
+"raw": "{\r\n  \"correo\": \"ricardo@example.com\",\r\n  \"contrasena\": \"123456789\"\r\n}\r\n",
+"options": {
+"raw": {
+"language": "json"
+}
+}
+},
+"url": {
+"raw": "http://54.210.246.199:80/api/usuarios/login",
+"protocol": "http",
+"host": [
+"54",
+"210",
+"246",
+"199"
+],
+"port": "80",
+"path": [
+"api",
+"usuarios",
+"login"
+]
+}
+},
+"response": []
+},
+{
+"name": "Registrar",
+"request": {
+"method": "POST",
+"header": [],
+"body": {
+"mode": "raw",
+"raw": "{\r\n  \"nombre\": \"Ricardo Rios\",\r\n  \"correo\": \"ricardo@example.com\",\r\n  \"contrasena\": \"123456789\",\r\n  \"rol\": \"admin\"\r\n}\r\n",
+"options": {
+"raw": {
+"language": "json"
+}
+}
+},
+"url": {
+"raw": "http://localhost:80/api/usuarios/registrar",
+"protocol": "http",
+"host": [
+"localhost"
+],
+"port": "80",
+"path": [
+"api",
+"usuarios",
+"registrar"
+]
+}
+},
+"response": []
+},
+{
+"name": "VerificarCorreo",
+"event": [
+{
+"listen": "test",
+"script": {
+"exec": [
+""
+],
+"type": "text/javascript",
+"packages": {}
+}
+}
+],
+"request": {
+"method": "POST",
+"header": [],
+"body": {
+"mode": "raw",
+"raw": "{\r\n  \"correo\": \"castroismael571@gmail.com\",\r\n  \"codigo\": \"\"\r\n}\r\n",
+"options": {
+"raw": {
+"language": "json"
+}
+}
+},
+"url": {
+"raw": "http://localhost:80/api/usuarios/verificar-correo",
+"protocol": "http",
+"host": [
+"localhost"
+],
+"port": "80",
+"path": [
+"api",
+"usuarios",
+"verificar-correo"
+]
+}
+},
+"response": []
+}
+]
+},
+{
+"name": "justificaciones",
+"item": [
+{
+"name": "crear",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+}
+]
+},
+{
+"name": "Eventos",
+"item": [
+{
+"name": "listar",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "finalizar",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "New Request",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "Crear evento",
+"request": {
+"auth": {
+"type": "bearer",
+"bearer": [
+{
+"key": "token",
+"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY4NjMxZGE1NWRiN2EwMjUzNzQzMTNjMCIsInJvbCI6ImVzdHVkaWFudGUiLCJjb3JyZW8iOiJyaWNhcmRvQGV4YW1wbGUuY29tIiwiaWF0IjoxNzUxMzQ0OTAzLCJleHAiOjE3NTEzNTkzMDN9.Eh09O-c2w78m7EZ6WzrL7eb3LrhAXL4R-xNfWeqXv4I",
+"type": "string"
+}
+]
+},
+"method": "POST",
+"header": [],
+"body": {
+"mode": "raw",
+"raw": "{\r\n  \"_id\": \"685c95717f3b2c6e451ed2ba\",\r\n  \"titulo\": \"Proyecto de Móvil\",\r\n  \"ubicacion\": {\r\n    \"latitud\": -2.170998,\r\n    \"longitud\": -79.922359\r\n  },\r\n  \"fechaInicio\": \"2025-06-30T21:00:00.000Z\",\r\n  \"rangoPermitido\": 100\r\n}\r\n",
+"options": {
+"raw": {
+"language": "json"
+}
+}
+},
+"url": {
+"raw": "http://localhost:80/api/eventos/crear",
+"protocol": "http",
+"host": [
+"localhost"
+],
+"port": "80",
+"path": [
+"api",
+"eventos",
+"crear"
+]
+}
+},
+"response": []
+},
+{
+"name": "GET EVENTOS",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+}
+]
+},
+{
+"name": "Asistencia",
+"item": [
+{
+"name": "REGISTRAR ASISTENCIA",
+"request": {
+"auth": {
+"type": "bearer",
+"bearer": [
+{
+"key": "token",
+"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY4NjMxZGE1NWRiN2EwMjUzNzQzMTNjMCIsInJvbCI6ImVzdHVkaWFudGUiLCJjb3JyZW8iOiJyaWNhcmRvQGV4YW1wbGUuY29tIiwiaWF0IjoxNzUxMzM1NzAwLCJleHAiOjE3NTEzNTAxMDB9.KPuTmZOcBs1GxvF1dd28E9HUXNZcou7ueadR103aU-k",
+"type": "string"
+}
+]
+},
+"method": "POST",
+"header": [],
+"body": {
+"mode": "raw",
+"raw": "{\r\n  \"eventoId\": \"685c95717f3b2c6e451ed2ba\",\r\n  \"latitud\": -3.9856,\r\n  \"longitud\": -79.2041\r\n}\r\n",
+"options": {
+"raw": {
+"language": "json"
+}
+}
+},
+"url": {
+"raw": "http://localhost:80/api/asistencia/registrar",
+"protocol": "http",
+"host": [
+"localhost"
+],
+"port": "80",
+"path": [
+"api",
+"asistencia",
+"registrar"
+]
+}
+},
+"response": []
+}
+]
+},
+{
+"name": "Dashboard",
+"item": [
+{
+"name": "DASHBOARD GET DATOS",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "Métricas por evento",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "Crear o actualizar una métrica",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+},
+{
+"name": "Datos estadísticos generales del dashboard",
+"request": {
+"method": "GET",
+"header": []
+},
+"response": []
+}
+]
+}
+]
+}
+

--- a/lib/api-config.ts
+++ b/lib/api-config.ts
@@ -3,9 +3,9 @@ export const API_CONFIG = {
   BASE_URL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:80",
   ENDPOINTS: {
     // Usuarios
-    REGISTER: "/usuarios/registrar",
-    LOGIN: "/usuarios/login",
-    VERIFY_EMAIL: "/usuarios/verificar-correo",
+    REGISTER: "/api/usuarios/registrar",
+    LOGIN: "/api/usuarios/login",
+    VERIFY_EMAIL: "/api/usuarios/verificar-correo",
 
     // Eventos
     CREATE_EVENT: "/api/eventos/crear",


### PR DESCRIPTION
## Summary
- prefix user API endpoints with `/api/` to match backend routes
- document available API endpoints and their usage in the UI
- add exported Postman collection for reference

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689181ff292483309ff7a0beffd52ee3