### PR TITLE
feat: send docente verification code

### DIFF
--- a/components/create-docente-modal.tsx
+++ b/components/create-docente-modal.tsx
@@ -42,8 +42,12 @@ export function CreateDocenteModal({ open, onOpenChange, onSuccess }: CreateDoce
 
     setIsVerifying(true)
     try {
-
-      setShowVerification(true)
+      const response = await apiService.sendDocenteVerificationCode(formData.email)
+      if (response.success) {
+        setShowVerification(true)
+      } else {
+        alert(response.message || "No se pudo enviar el código de verificación")
+      }
     } catch (error) {
       console.error("Error sending verification code:", error)
       alert("No se pudo enviar el código de verificación")
@@ -86,7 +90,7 @@ export function CreateDocenteModal({ open, onOpenChange, onSuccess }: CreateDoce
 
       if (response.success) {
         const newDocente: Docente = {
-          id: response.data?.id || Date.now().toString(),
+          id: (response.data as any)?.id || (response.data as any)?._id || Date.now().toString(),
           name: formData.name,
           email: formData.email,
           createdAt: new Date().toISOString().split("T")[0],

--- a/lib/api-config.ts
+++ b/lib/api-config.ts
@@ -6,6 +6,7 @@ export const API_CONFIG = {
     REGISTER: "/api/usuarios/registrar",
     LOGIN: "/api/usuarios/login",
     VERIFY_EMAIL: "/api/usuarios/verificar-correo",
+    DOCENTE_SEND_CODE: "/api/usuarios/enviar-codigo",
 
     // Eventos
     CREATE_EVENT: "/api/eventos/crear",


### PR DESCRIPTION
## Summary
- add missing endpoint for sending verification codes to docentes
- send verification code and use backend id when creating docentes

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68919e2ff2048330954f014ebfc1219d