### PR TITLE
refactor: rename websocket hook and document API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Continue building your app on:
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
 
+## Environment
+
+Configure the API base URL through the `NEXT_PUBLIC_API_URL` environment
+variable so the dashboard can display live data from the backend:
+
+```bash
+# .env.local
+NEXT_PUBLIC_API_URL=http://localhost:80
+```
+
 ## API Endpoints
 
 The project consumes a REST API whose endpoints are documented in
@@ -42,7 +52,7 @@ below shows how each endpoint is used inside the application:
 | `/api/eventos/listar` | `getEvents` | `hooks/use-events.ts` → `<EventsManagement />` |
 | `/api/eventos/finalizar` | `finalizeEvent` | `hooks/use-events.ts` → `<EventsManagement />` |
 | `/api/asistencia/registrar` | `registerAttendance` | _Attendance registration (future pages)_ |
-| `/api/dashboard/datos` | `getDashboardData` | `hooks/use-websocket.ts` → `<EnhancedDashboard />` |
+| `/api/dashboard/datos` | `getDashboardData` | `hooks/use-dashboard-data.ts` → `<EnhancedDashboard />` |
 | `/api/justificaciones/crear` | `createJustification` | _Justification creation (future pages)_ |
 
 These mappings make it easier to locate where each API call is triggered in

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useWebSocket } from "@/hooks/use-websocket"
+import { useDashboardData } from "@/hooks/use-dashboard-data"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { BarChart3, Users, Calendar, TrendingUp, Download, Wifi, WifiOff } from "lucide-react"
 
 export function DashboardContent() {
-  const { stats, isConnected } = useWebSocket()
+  const { stats, isConnected } = useDashboardData()
 
   const handleExportPDF = () => {
     // Simular exportación PDF

--- a/components/enhanced-dashboard.tsx
+++ b/components/enhanced-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useWebSocket } from "@/hooks/use-websocket"
+import { useDashboardData } from "@/hooks/use-dashboard-data"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,7 +19,7 @@ import {
 } from "lucide-react"
 
 export function EnhancedDashboard() {
-  const { stats, isConnected, isLoading, refetch } = useWebSocket()
+  const { stats, isConnected, isLoading, refetch } = useDashboardData()
 
   const handleExportPDF = () => {
     // Simular exportación PDF

--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { apiService } from "@/lib/api-service"
 import type { AttendanceStats } from "@/types"
 
-export function useWebSocket() {
+export function useDashboardData() {
   const [stats, setStats] = useState<AttendanceStats>({
     totalEvents: 0,
     activeEvents: 0,


### PR DESCRIPTION
## Summary
- rename useWebSocket hook to useDashboardData and keep stats in sync with API
- update dashboard components to consume new hook
- document NEXT_PUBLIC_API_URL env var and updated API mapping

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: ERR_PNPM_FETCH_403 - Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891c3cba66c8330a2833800995b12fa