### PR TITLE
feat: fetch dashboard overview data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Continue building your app on:
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
 
+## Environment
+
+Configure the API base URL through the `NEXT_PUBLIC_API_URL` environment
+variable so the dashboard can display live data from the backend:
+
+```bash
+# .env.local
+NEXT_PUBLIC_API_URL=http://localhost:80
+```
+
 ## API Endpoints
 
 The project consumes a REST API whose endpoints are documented in
@@ -42,7 +52,7 @@ below shows how each endpoint is used inside the application:
 | `/api/eventos/listar` | `getEvents` | `hooks/use-events.ts` → `<EventsManagement />` |
 | `/api/eventos/finalizar` | `finalizeEvent` | `hooks/use-events.ts` → `<EventsManagement />` |
 | `/api/asistencia/registrar` | `registerAttendance` | _Attendance registration (future pages)_ |
-| `/api/dashboard/datos` | `getDashboardData` | `hooks/use-websocket.ts` → `<EnhancedDashboard />` |
+| `/api/dashboard/overview` | `getDashboardData` | `hooks/use-dashboard-data.ts` → `<EnhancedDashboard />` |
 | `/api/justificaciones/crear` | `createJustification` | _Justification creation (future pages)_ |
 
 These mappings make it easier to locate where each API call is triggered in

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useWebSocket } from "@/hooks/use-websocket"
+import { useDashboardData } from "@/hooks/use-dashboard-data"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { BarChart3, Users, Calendar, TrendingUp, Download, Wifi, WifiOff } from "lucide-react"
 
 export function DashboardContent() {
-  const { stats, isConnected } = useWebSocket()
+  const { stats, isConnected } = useDashboardData()
 
   const handleExportPDF = () => {
     // Simular exportación PDF
@@ -42,7 +42,11 @@ export function DashboardContent() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stats.totalEvents}</div>
-            <p className="text-xs text-muted-foreground">+2 desde el mes pasado</p>
+            <p className="text-xs text-muted-foreground">
+              {typeof stats.monthlyEventChange === "number"
+                ? `${stats.monthlyEventChange > 0 ? "+" : ""}${stats.monthlyEventChange.toFixed(2)}% desde el mes pasado`
+                : "Sin datos previos"}
+            </p>
           </CardContent>
         </Card>
 
@@ -64,7 +68,11 @@ export function DashboardContent() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stats.totalAttendees.toLocaleString()}</div>
-            <p className="text-xs text-muted-foreground">+12% desde la semana pasada</p>
+            <p className="text-xs text-muted-foreground">
+              {typeof stats.weeklyAttendanceChange === "number"
+                ? `${stats.weeklyAttendanceChange > 0 ? "+" : ""}${stats.weeklyAttendanceChange.toFixed(2)}% desde la semana pasada`
+                : "Sin datos previos"}
+            </p>
           </CardContent>
         </Card>
 
@@ -74,8 +82,8 @@ export function DashboardContent() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{stats.averageAttendance}%</div>
-            <p className="text-xs text-muted-foreground">+5% desde el mes pasado</p>
+            <div className="text-2xl font-bold">{stats.averageAttendance.toFixed(2)}%</div>
+            <p className="text-xs text-muted-foreground">Promedio global</p>
           </CardContent>
         </Card>
       </div>
@@ -94,7 +102,7 @@ export function DashboardContent() {
                   <div className="flex-1">
                     <p className="text-sm font-medium">{activity.eventName}</p>
                     <p className="text-xs text-muted-foreground">
-                      {activity.attendeeCount} asistentes • {new Date(activity.timestamp).toLocaleTimeString()}
+                      {new Date(activity.timestamp).toLocaleString()}
                     </p>
                   </div>
                 </div>
@@ -110,29 +118,24 @@ export function DashboardContent() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm">Conferencias</span>
-                <span className="text-sm font-medium">45%</span>
-              </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div className="bg-blue-600 h-2 rounded-full" style={{ width: "45%" }}></div>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <span className="text-sm">Seminarios</span>
-                <span className="text-sm font-medium">35%</span>
-              </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div className="bg-green-600 h-2 rounded-full" style={{ width: "35%" }}></div>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <span className="text-sm">Clases</span>
-                <span className="text-sm font-medium">20%</span>
-              </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div className="bg-yellow-600 h-2 rounded-full" style={{ width: "20%" }}></div>
-              </div>
+              {stats.eventsByType.map((item, index) => {
+                const colors = ["bg-blue-600", "bg-green-600", "bg-yellow-600", "bg-purple-600"]
+                const color = colors[index % colors.length]
+                return (
+                  <div key={index}>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">{item.type}</span>
+                      <span className="text-sm font-medium">{item.percentage.toFixed(0)}%</span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2">
+                      <div
+                        className={`${color} h-2 rounded-full`}
+                        style={{ width: `${item.percentage}%` }}
+                      ></div>
+                    </div>
+                  </div>
+                )
+              })}
             </div>
           </CardContent>
         </Card>

--- a/components/enhanced-dashboard.tsx
+++ b/components/enhanced-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useWebSocket } from "@/hooks/use-websocket"
+import { useDashboardData } from "@/hooks/use-dashboard-data"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,7 +19,7 @@ import {
 } from "lucide-react"
 
 export function EnhancedDashboard() {
-  const { stats, isConnected, isLoading, refetch } = useWebSocket()
+  const { stats, isConnected, isLoading, refetch } = useDashboardData()
 
   const handleExportPDF = () => {
     // Simular exportación PDF

--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -4,13 +4,16 @@ import { useState, useEffect } from "react"
 import { apiService } from "@/lib/api-service"
 import type { AttendanceStats } from "@/types"
 
-export function useWebSocket() {
+export function useDashboardData() {
   const [stats, setStats] = useState<AttendanceStats>({
     totalEvents: 0,
+    monthlyEventChange: null,
     activeEvents: 0,
     totalAttendees: 0,
+    weeklyAttendanceChange: null,
     averageAttendance: 0,
     recentActivity: [],
+    eventsByType: [],
   })
   const [isConnected, setIsConnected] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -23,14 +26,21 @@ export function useWebSocket() {
       if (response.data) {
         setStats({
           totalEvents: response.data.totalEventos,
+          monthlyEventChange: response.data.cambioEventosMes ?? null,
           activeEvents: response.data.eventosActivos,
           totalAttendees: response.data.totalAsistentes,
-          averageAttendance: response.data.promedioAsistencia,
-          recentActivity: response.data.actividadReciente.map((activity) => ({
-            eventName: activity.nombreEvento,
-            attendeeCount: activity.cantidadAsistentes,
-            timestamp: activity.timestamp,
-          })),
+          weeklyAttendanceChange: response.data.cambioAsistenciasSemana ?? null,
+          averageAttendance: response.data.promedioAsistenciaPorcentaje,
+          recentActivity:
+            response.data.actividadReciente?.map((activity) => ({
+              eventName: activity.nombre,
+              timestamp: activity.createdAt,
+            })) || [],
+          eventsByType:
+            response.data.eventosPorTipo?.map((t) => ({
+              type: t.tipo,
+              percentage: t.porcentaje,
+            })) || [],
         })
         setIsConnected(true)
       }
@@ -40,10 +50,13 @@ export function useWebSocket() {
       // Mantener datos por defecto en caso de error
       setStats({
         totalEvents: 0,
+        monthlyEventChange: null,
         activeEvents: 0,
         totalAttendees: 0,
+        weeklyAttendanceChange: null,
         averageAttendance: 0,
         recentActivity: [],
+        eventsByType: [],
       })
     } finally {
       setIsLoading(false)

--- a/lib/api-config.ts
+++ b/lib/api-config.ts
@@ -20,7 +20,7 @@ export const API_CONFIG = {
     REGISTER_ATTENDANCE: "/api/asistencia/registrar",
 
     // Dashboard
-    DASHBOARD_DATA: "/api/dashboard/datos",
+    DASHBOARD_DATA: "/api/dashboard/overview",
 
     // Justificaciones
     CREATE_JUSTIFICATION: "/api/justificaciones/crear",
@@ -61,12 +61,31 @@ export interface EventoBackend {
 
 export interface DashboardData {
   totalEventos: number
+  cambioEventosMes: number | null
   eventosActivos: number
   totalAsistentes: number
-  promedioAsistencia: number
+  cambioAsistenciasSemana: number | null
+  promedioAsistenciaPorcentaje: number
+  eventosPorTipo: {
+    tipo: string
+    porcentaje: number
+  }[]
+  tendenciaAsistenciaMensual: {
+    mes: string
+    total: number
+  }[]
+  asistenciaPorDia: {
+    dia: string
+    total: number
+  }[]
+  asistenciaPorHora: {
+    hora: number
+    total: number
+  }[]
   actividadReciente: {
-    nombreEvento: string
-    cantidadAsistentes: number
-    timestamp: string
+    nombre: string
+    fechaInicio: string
+    fechaFin: string
+    createdAt: string
   }[]
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,12 +41,17 @@ export interface Event {
 
 export interface AttendanceStats {
   totalEvents: number
+  monthlyEventChange: number | null
   activeEvents: number
   totalAttendees: number
+  weeklyAttendanceChange: number | null
   averageAttendance: number
   recentActivity: {
     eventName: string
-    attendeeCount: number
     timestamp: string
+  }[]
+  eventsByType: {
+    type: string
+    percentage: number
   }[]
 }


### PR DESCRIPTION
## Summary
- load dashboard metrics from /api/dashboard/overview and expose new fields
- show monthly/weekly changes, average attendance and distribution by type in dashboard
- document new dashboard endpoint

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: ERR_PNPM_FETCH_403 - Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891c3cba66c8330a2833800995b12fa