### PR TITLE
fix: ensure dashboard stats defaults

### DIFF
--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -5,10 +5,17 @@ import { apiService } from "@/lib/api-service"
 import type { AttendanceStats } from "@/types"
 
 export function useDashboardData() {
-  const [stats, setStats] = useState<AttendanceStats>({
+  const initialStats: AttendanceStats = {
     totalEvents: 0,
-
-  })
+    monthlyEventChange: null,
+    activeEvents: 0,
+    totalAttendees: 0,
+    weeklyAttendanceChange: null,
+    averageAttendance: 0,
+    recentActivity: [],
+    eventsByType: [],
+  }
+  const [stats, setStats] = useState<AttendanceStats>(initialStats)
   const [isConnected, setIsConnected] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 
@@ -18,8 +25,22 @@ export function useDashboardData() {
       const response = await apiService.getDashboardData()
 
       if (response.data) {
+        const data = response.data
         setStats({
-          totalEvents: response.data.totalEventos,
+          totalEvents: data.totalEventos ?? 0,
+          monthlyEventChange: data.cambioEventosMes ?? null,
+          activeEvents: data.eventosActivos ?? 0,
+          totalAttendees: data.totalAsistentes ?? 0,
+          weeklyAttendanceChange: data.cambioAsistenciasSemana ?? null,
+          averageAttendance: data.promedioAsistenciaPorcentaje ?? 0,
+          recentActivity: (data.actividadReciente ?? []).map((item) => ({
+            eventName: item.nombre,
+            timestamp: item.createdAt,
+          })),
+          eventsByType: (data.eventosPorTipo ?? []).map((item) => ({
+            type: item.tipo,
+            percentage: item.porcentaje,
+          })),
         })
         setIsConnected(true)
       }
@@ -27,10 +48,7 @@ export function useDashboardData() {
       console.error("Error fetching dashboard data:", error)
       setIsConnected(false)
       // Mantener datos por defecto en caso de error
-      setStats({
-        totalEvents: 0,
-
-      })
+      setStats(initialStats)
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary
- provide default statistics in dashboard hook so data fields are always defined
- map dashboard API response to populate stats like total attendees and activity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929923d138833080e6df7f5ad8fc89