### PR TITLE
feat: add attendance trend stats

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -54,4 +54,7 @@ export interface AttendanceStats {
     type: string
     percentage: number
   }[]
+  monthlyAttendanceTrend: { month: string; total: number }[] // tendencia mensual de asistencia
+  attendanceByDay: { day: string; total: number }[] // asistencia total por día
+  attendanceByHour: { hour: number; total: number }[] // asistencia total por hora del día
 }


### PR DESCRIPTION
## Summary
- add monthly, daily and hourly attendance metrics to `AttendanceStats`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed; installation attempt returned 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68929b1059d483308fd096bb4419d025