### PR TITLE
feat: add detailed attendance stats

### DIFF
--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -14,6 +14,9 @@ export function useDashboardData() {
     averageAttendance: 0,
     recentActivity: [],
     eventsByType: [],
+    monthlyAttendanceTrend: [],
+    attendanceByDay: [],
+    attendanceByHour: [],
   }
   const [stats, setStats] = useState<AttendanceStats>(initialStats)
   const [isConnected, setIsConnected] = useState(false)
@@ -35,11 +38,27 @@ export function useDashboardData() {
           averageAttendance: data.promedioAsistenciaPorcentaje ?? 0,
           recentActivity: (data.actividadReciente ?? []).map((item) => ({
             eventName: item.nombre,
+            eventStart: item.fechaInicio,
+            eventEnd: item.fechaFin,
             timestamp: item.createdAt,
           })),
           eventsByType: (data.eventosPorTipo ?? []).map((item) => ({
             type: item.tipo,
             percentage: item.porcentaje,
+          })),
+          monthlyAttendanceTrend: (data.tendenciaAsistenciaMensual ?? []).map(
+            (item) => ({
+              month: item.mes,
+              total: item.total,
+            })
+          ),
+          attendanceByDay: (data.asistenciaPorDia ?? []).map((item) => ({
+            day: item.dia,
+            total: item.total,
+          })),
+          attendanceByHour: (data.asistenciaPorHora ?? []).map((item) => ({
+            hour: item.hora,
+            total: item.total,
           })),
         })
         setIsConnected(true)

--- a/types/index.ts
+++ b/types/index.ts
@@ -48,10 +48,24 @@ export interface AttendanceStats {
   averageAttendance: number
   recentActivity: {
     eventName: string
+    eventStart: string
+    eventEnd: string
     timestamp: string
   }[]
   eventsByType: {
     type: string
     percentage: number
+  }[]
+  monthlyAttendanceTrend: {
+    month: string
+    total: number
+  }[]
+  attendanceByDay: {
+    day: string
+    total: number
+  }[]
+  attendanceByHour: {
+    hour: number
+    total: number
   }[]
 }


### PR DESCRIPTION
## Summary
- extend dashboard stats with monthly, daily and hourly attendance arrays
- map API data to new stats and include full recent activity fields
- update AttendanceStats type definitions accordingly

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68929b13a65c83308d46a3e8b61006ba