### PR TITLE
Display time only for recent dashboard activity

### DIFF
--- a/components/enhanced-dashboard.tsx
+++ b/components/enhanced-dashboard.tsx
@@ -140,7 +140,7 @@ export function EnhancedDashboard() {
                     <div className="flex-1">
                       <p className="text-sm font-medium">{activity.eventName}</p>
                       <p className="text-xs text-muted-foreground">
-                        {activity.attendeeCount} asistentes • {new Date(activity.timestamp).toLocaleTimeString()}
+                        {new Date(activity.timestamp).toLocaleTimeString()}
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- show only the activity time in the enhanced dashboard recent activity list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm install eslint --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68929b145a0c8330ada0a19fc37c12e9